### PR TITLE
Added $templateCache support.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,9 +20,14 @@ module.exports = function (grunt) {
                 }
             }
         },
-        clean: [
-            './dist/'
-        ],
+        clean: {
+            allDist: {
+                src: ['./dist/']
+            },
+            htmlDist: {
+                src: ['./dist/src/**/*.html']
+            }
+        },
         ngtemplates: {
             default: {
                 src: 'app/src/**/*.html',
@@ -41,12 +46,49 @@ module.exports = function (grunt) {
             tasks: ['less']
         },
         copy: {
-            main: {
+            all: {
                 files: [
                     {
                         expand: true,
                         cwd: './app',
                         src: ['**'],
+                        dest: 'dist/',
+                        flatten: false,
+                        filter: 'isFile'
+                    }
+                ]
+            },
+            noViews: {
+                files: [
+                    {
+                        expand: true,
+                        cwd: './app/src',
+                        src: ['**/*.js'],
+                        exclude: ['**/*Spec.js'],
+                        dest: 'dist/',
+                        flatten: false,
+                        filter: 'isFile'
+                    },
+                    {
+                        expand: true,
+                        cwd: './app/vendor',
+                        src: ['**/*.js'],
+                        dest: 'dist/vendor',
+                        flatten: false,
+                        filter: 'isFile'
+                    },
+                    {
+                        expand: true,
+                        cwd: './app/assets',
+                        src: ['css/**/*.css','fonts/**'],
+                        dest: 'dist/assets',
+                        flatten: false,
+                        filter: 'isFile'
+                    },
+                    {
+                        expand: true,
+                        cwd: './app',
+                        src: ['*.js','*.html'],
                         dest: 'dist/',
                         flatten: false,
                         filter: 'isFile'
@@ -95,6 +137,18 @@ module.exports = function (grunt) {
 
 
     grunt.registerTask('default', ['bowerRequirejs']);
-    grunt.registerTask('dist', ['less', 'copy', 'requirejs']);
+    grunt.registerTask('dist', 'generates a dist version', function(){
+        var tasks = ['clean:allDist','less'];
+        if(grunt.option('templateCache'))
+        {
+            tasks.push('copy:noViews');
+        } else {
+            tasks.push('copy:all');
+        }
+        tasks.push('ngtemplates');
+        tasks.push('requirejs');
+        grunt.task.run(tasks);
+
+    });
 
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -24,18 +24,31 @@ module.exports = function (grunt) {
             allDist: {
                 src: ['./dist/']
             },
-            htmlDist: {
-                src: ['./dist/src/**/*.html']
+            templateCache: {
+                src: [
+                    './dist/**/view',
+                    './dist/**/test',
+                    './dist/**/less',
+                    './dist/**/sass'
+                ]
+            }
+        },
+        cleanempty: {
+            templateCache: {
+                options: {
+                    files: false
+                },
+                src: ['dist/**/*']
             }
         },
         ngtemplates: {
             default: {
                 src: 'app/src/**/*.html',
-                dest: 'dist/src/resources/views.js',
+                dest: 'app/src/resources/views.js',
                 options: {
                     module: "resources.views",
-                    standalone:true,
-                    url: function(path) {
+                    standalone: true,
+                    url: function (path) {
                         return path.substring('app/'.length);
                     }
                 }
@@ -51,44 +64,7 @@ module.exports = function (grunt) {
                     {
                         expand: true,
                         cwd: './app',
-                        src: ['**'],
-                        dest: 'dist/',
-                        flatten: false,
-                        filter: 'isFile'
-                    }
-                ]
-            },
-            noViews: {
-                files: [
-                    {
-                        expand: true,
-                        cwd: './app/src',
-                        src: ['**/*.js'],
-                        exclude: ['**/*Spec.js'],
-                        dest: 'dist/',
-                        flatten: false,
-                        filter: 'isFile'
-                    },
-                    {
-                        expand: true,
-                        cwd: './app/vendor',
-                        src: ['**/*.js'],
-                        dest: 'dist/vendor',
-                        flatten: false,
-                        filter: 'isFile'
-                    },
-                    {
-                        expand: true,
-                        cwd: './app/assets',
-                        src: ['css/**/*.css','fonts/**'],
-                        dest: 'dist/assets',
-                        flatten: false,
-                        filter: 'isFile'
-                    },
-                    {
-                        expand: true,
-                        cwd: './app',
-                        src: ['*.js','*.html'],
+                        src: ['**', '!**/*Spec.js'],
                         dest: 'dist/',
                         flatten: false,
                         filter: 'isFile'
@@ -106,7 +82,7 @@ module.exports = function (grunt) {
                         {name: 'app'}
                     ],
                     dir: "./dist",
-                    keepBuildDir: true,
+                    keepBuildDir: false,
                     locale: "en-us",
                     optimize: "uglify2",
                     skipDirOptimize: false,
@@ -137,16 +113,17 @@ module.exports = function (grunt) {
 
 
     grunt.registerTask('default', ['bowerRequirejs']);
-    grunt.registerTask('dist', 'generates a dist version', function(){
-        var tasks = ['clean:allDist','less'];
-        if(grunt.option('templateCache'))
-        {
-            tasks.push('copy:noViews');
-        } else {
-            tasks.push('copy:all');
+    grunt.registerTask('dist', 'generates a dist version', function () {
+        var tasks = ['clean:allDist',
+            'less',
+            'ngtemplates',
+            'copy:all',
+            'requirejs'];
+
+        if (grunt.option('templateCache')) {
+            tasks.push('clean:templateCache');
         }
-        tasks.push('ngtemplates');
-        tasks.push('requirejs');
+        tasks.push('cleanempty');
         grunt.task.run(tasks);
 
     });

--- a/app/assets/css/bootstrap.custom.min.css
+++ b/app/assets/css/bootstrap.custom.min.css
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css?family=Lato:400,700,400italic");/*!
+/*!
  * bootswatch v3.3.4+1
  * Homepage: http://bootswatch.com
  * Copyright 2012-2015 Thomas Park

--- a/app/index.html
+++ b/app/index.html
@@ -13,6 +13,7 @@
     <title>Scalable AngularJS App</title>
     <meta name="description" content="">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700,400italic"/>
     <link rel="stylesheet" href="assets/css/bootstrap.custom.min.css"/>
     <link rel="stylesheet" href="assets/css/main.min.css"/>
     <script data-main="main.js" src="vendor/requirejs/require.js"></script>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -51,7 +51,7 @@ module.exports = function (config) {
 
 
         // enable / disable watching file and executing tests whenever any file changes
-        autoWatch: true,
+        autoWatch: false,
 
 
         // Start these browsers, currently available:

--- a/package.json
+++ b/package.json
@@ -2,9 +2,9 @@
   "name": "angular-scalable-project",
   "description": "Skeleton to build scalable single-page applications",
   "author": {
-    "name" : "Daniel Salvagni",
-    "email" : "danielsalvagni@gmail.com",
-    "url" : "http://dsalvagni.com.br"
+    "name": "Daniel Salvagni",
+    "email": "danielsalvagni@gmail.com",
+    "url": "http://dsalvagni.com.br"
   },
   "repository": "dsalvagni/angular-scalable-project",
   "devDependencies": {
@@ -12,6 +12,7 @@
     "grunt": "^0.4.*",
     "grunt-angular-templates": "^0.5.7",
     "grunt-bower-requirejs": "^2.0.0",
+    "grunt-cleanempty": "^1.0.3",
     "grunt-contrib-clean": "^0.6.0",
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-less": "^1.0.1",


### PR DESCRIPTION
It is now possible to generate a dist version without partials or html views by running the dist task with the _templateCache_ flag.

> grunt dist --templateCache

The distribution folder will look like the image below.
All partials and views will now be within _app.js_ bundle file.

![dist-folder](https://cloud.githubusercontent.com/assets/1139226/9837289/986ac4c8-5a10-11e5-8130-ec0b66c0c738.PNG)

fix #3 
